### PR TITLE
remove nmcli execution for all rhel releases

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,10 +7,7 @@ class network::params {
   $service_restart_exec = $::osfamily ? {
     'Debian'  => '/sbin/ifdown -a --force ; /sbin/ifup -a',
     'Solaris' => '/usr/sbin/svcadm restart svc:/network/physical:default',
-    'RedHat'  => $::operatingsystemmajrelease ? {
-      '8'     => 'nmcli connection reload && nmcli networking off && nmcli networking on',
-      default => 'service network restart',
-    },
+    'RedHat'  => 'service network restart',
     default   => 'service network restart',
   }
 


### PR DESCRIPTION
Removes nmcli execution in all RHEL releases. See: C2OPS-11044. 

